### PR TITLE
remove cel.HomogeneousAggregateLiterals

### DIFF
--- a/pkg/render2/celrenderer/cel.go
+++ b/pkg/render2/celrenderer/cel.go
@@ -36,7 +36,6 @@ func IsCelExpression(s string) (bool, error) {
 
 func getCelEnv(vars map[string]any) (*cel.Env, error) {
 	var opts []cel.EnvOption
-	opts = append(opts, cel.HomogeneousAggregateLiterals())
 	opts = append(opts, cel.EagerlyValidateDeclarations(true), cel.DefaultUTCTimeZone(true))
 	//opts = append(opts, library.ExtensionLibs...)
 


### PR DESCRIPTION
The concat function does not have a homogeneous list of parameters, it has type dyn and string. See [example2](https://github.com/kform-dev/kform-examples/blob/main/example2/workload-cluster.yaml#L4) for such an example which fails using the cel.HomogeneousAggregateLiterals validator. Removing this validator renders the concat function usable again.