### PR TITLE
Feature/split string.split(separator, limit)

### DIFF
--- a/pkg/render2/celrenderer/cel.go
+++ b/pkg/render2/celrenderer/cel.go
@@ -36,7 +36,6 @@ func IsCelExpression(s string) (bool, error) {
 
 func getCelEnv(vars map[string]any) (*cel.Env, error) {
 	var opts []cel.EnvOption
-	opts = append(opts, cel.HomogeneousAggregateLiterals())
 	opts = append(opts, cel.EagerlyValidateDeclarations(true), cel.DefaultUTCTimeZone(true))
 	//opts = append(opts, library.ExtensionLibs...)
 

--- a/pkg/render2/celrenderer/cel.go
+++ b/pkg/render2/celrenderer/cel.go
@@ -57,6 +57,25 @@ func getCelEnv(vars map[string]any) (*cel.Env, error) {
 			}),
 		),
 	))
+	// # Split
+	//
+	// Returns a list of strings split from the input by the given separator. The function accepts
+	// an optional argument specifying a limit on the number of substrings produced by the split.
+	//
+	// When the split limit is 0, the result is an empty list. When the limit is 1, the result is the
+	// target string to split. When the limit is a negative number, the function behaves the same as
+	// split all.
+	//
+	//	<string>.split(<string>) -> <list<string>>
+	//	<string>.split(<string>, <int>) -> <list<string>>
+	//
+	// Examples:
+	//
+	//	'hello hello hello'.split(' ')     // returns ['hello', 'hello', 'hello']
+	//	'hello hello hello'.split(' ', 0)  // returns []
+	//	'hello hello hello'.split(' ', 1)  // returns ['hello hello hello']
+	//	'hello hello hello'.split(' ', 2)  // returns ['hello', 'hello hello']
+	//	'hello hello hello'.split(' ', -1) // returns ['hello', 'hello', 'hello']
 	opts = append(opts, cel.Function("split",
 		cel.MemberOverload("string_split_string",
 			[]*cel.Type{cel.StringType,


### PR DESCRIPTION
Added split function in the same way that concat was added with code from https://github.com/google/cel-go/blob/master/ext/strings.go#L425

Find usage in comments in code.