### PR TITLE
added case for []string in forEach loop

### DIFF
--- a/pkg/exec/fn/fns/block_exec_handler.go
+++ b/pkg/exec/fn/fns/block_exec_handler.go
@@ -169,6 +169,12 @@ func (r *ExecHandler) getLoopItems(ctx context.Context, attr *kformv1alpha1.Attr
 			}
 			log.Debug("getLoopItems forEach render output", "value type", reflect.TypeOf(v), "value", v)
 			switch v := v.(type) {
+			case []string:
+				// in a list we return key = int, val = any
+				for k, v := range v {
+					log.Debug("getLoopItems forEach insert item", "k", k, "v", v)
+					items.Add(k, item{key: k, val: v})
+				}
 			case []any:
 				// in a list we return key = int, val = any
 				for k, v := range v {


### PR DESCRIPTION
In the strict Go type system, []string does not match []any.

For an annotation like below v is of type interface {}([]string): 
`kform.dev/for-each: "input.context[0].data.entries.split(\".\")"`
with input 
`input.context[0].data.entries: "a.b.c"`

This would be handled by the default case and only generate a single item and not 3 items as expected by for-each.